### PR TITLE
Fixes for /reload & Registries

### DIFF
--- a/common/src/main/java/fzzyhmstrs/emi_loot/parser/LootTableParser.java
+++ b/common/src/main/java/fzzyhmstrs/emi_loot/parser/LootTableParser.java
@@ -71,7 +71,7 @@ public class LootTableParser {
         return true;
     }
 
-    public void registerServer(ServerPlayerEntity player){
+    public void registerServer(List<ServerPlayerEntity> players){
         if (!hasPostProcessed()){
             EMILoot.LOGGER.warn("Post-processing not completed for some reason, completing now...");
             for (PostProcessor process: PostProcessor.values()){
@@ -79,17 +79,19 @@ public class LootTableParser {
             }
             EMILoot.LOGGER.warn("Post-processing complete!");
         }
-        PacketSender.s2c(player).send(CLEAR_LOOTS, new PacketByteBuf(Unpooled.buffer()));
-        if (EMILoot.config.parseChestLoot)
-            chestSenders.forEach((id,chestSender) -> chestSender.send(player));
-        if (EMILoot.config.parseBlockLoot)
-            blockSenders.forEach((id,blockSender) -> blockSender.send(player));
-        if (EMILoot.config.parseMobLoot)
-            mobSenders.forEach((id,mobSender) -> mobSender.send(player));
-        if (EMILoot.config.parseGameplayLoot)
-            gameplaySenders.forEach((id,gameplaySender) -> gameplaySender.send(player));
-        if (EMILoot.config.parseArchaeologyLoot)
-            archaeologySenders.forEach((id, archaeologySender) -> archaeologySender.send(player));
+        players.forEach(player -> {
+            PacketSender.s2c(player).send(CLEAR_LOOTS, new PacketByteBuf(Unpooled.buffer()));
+            if (EMILoot.config.parseChestLoot)
+                chestSenders.forEach((id,chestSender) -> chestSender.send(player));
+            if (EMILoot.config.parseBlockLoot)
+                blockSenders.forEach((id,blockSender) -> blockSender.send(player));
+            if (EMILoot.config.parseMobLoot)
+                mobSenders.forEach((id,mobSender) -> mobSender.send(player));
+            if (EMILoot.config.parseGameplayLoot)
+                gameplaySenders.forEach((id,gameplaySender) -> gameplaySender.send(player));
+            if (EMILoot.config.parseArchaeologyLoot)
+                archaeologySenders.forEach((id, archaeologySender) -> archaeologySender.send(player));
+        });
     }
 
     public static void parseLootTables(LootManager manager, Map<LootDataKey<?>, ?> tables) {

--- a/fabric/src/main/java/fzzyhmstrs/emi_loot/fabric/EMILootFabric.java
+++ b/fabric/src/main/java/fzzyhmstrs/emi_loot/fabric/EMILootFabric.java
@@ -4,6 +4,8 @@ import fzzyhmstrs.emi_loot.EMILoot;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 
+import java.util.List;
+
 public class EMILootFabric implements ModInitializer {
     @Override
     public void onInitialize() {
@@ -11,7 +13,7 @@ public class EMILootFabric implements ModInitializer {
         EMILoot.register();
 
         ServerLifecycleEvents.SYNC_DATA_PACK_CONTENTS.register((player, joined) ->{
-            EMILoot.parser.registerServer(player);
+            EMILoot.parser.registerServer(List.of(player));
         });
     }
 }

--- a/forge/src/main/java/fzzyhmstrs/emi_loot/forge/EMILootForge.java
+++ b/forge/src/main/java/fzzyhmstrs/emi_loot/forge/EMILootForge.java
@@ -4,6 +4,7 @@ import fzzyhmstrs.emi_loot.EMILoot;
 import fzzyhmstrs.emi_loot.forge.events.EMILootClientForgeEvents;
 import fzzyhmstrs.emi_loot.forge.events.EMILootClientModEvents;
 import fzzyhmstrs.emi_loot.forge.events.EMILootForgeEvents;
+import fzzyhmstrs.emi_loot.forge.events.EMILootModEvents;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -18,7 +19,7 @@ public class EMILootForge {
         //EventBuses.registerModEventBus(EMILoot.MOD_ID, MOD_BUS);
 
         MinecraftForge.EVENT_BUS.register(new EMILootForgeEvents());
-        //MOD_BUS.register(new EMILootModEvents());
+        MOD_BUS.register(new EMILootModEvents());
 
         if (FMLEnvironment.dist == Dist.CLIENT) {
             MinecraftForge.EVENT_BUS.register(new EMILootClientForgeEvents());

--- a/forge/src/main/java/fzzyhmstrs/emi_loot/forge/events/EMILootForgeEvents.java
+++ b/forge/src/main/java/fzzyhmstrs/emi_loot/forge/events/EMILootForgeEvents.java
@@ -1,18 +1,23 @@
 package fzzyhmstrs.emi_loot.forge.events;
 
 import fzzyhmstrs.emi_loot.EMILoot;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraftforge.event.OnDatapackSyncEvent;
+import net.minecraftforge.event.entity.EntityJoinLevelEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.registries.RegisterEvent;
+
+import java.util.List;
 
 public class EMILootForgeEvents {
     @SubscribeEvent
-    public void onRegister(RegisterEvent event) {
-        EMILoot.register();
+    public void onDatapackSync(OnDatapackSyncEvent event) {
+        EMILoot.parser.registerServer(event.getPlayerList().getPlayerList());
     }
 
     @SubscribeEvent
-    public void onDatapackSync(OnDatapackSyncEvent event) {
-        EMILoot.parser.registerServer(event.getPlayer());
+    public void onPlayerJoin(EntityJoinLevelEvent event) {
+        if(event.getEntity() instanceof ServerPlayerEntity player) {
+            EMILoot.parser.registerServer(List.of(player));
+        }
     }
 }


### PR DESCRIPTION
This fixes the errors when running /reload in game, in addition to properly registering lootify loot conditions & functions on Forge.